### PR TITLE
update build file

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,7 +1,7 @@
 Instructions for building the project
 =====================================
 1. Download and install [Visual Studio Community 2017](https://www.visualstudio.com/downloads).
-   SDK 8.1 should be selected when installing.
+   **Desktop development with C++** workload should be selected when installing.
 2. Download and install [CMake](https://cmake.org/download).
 3. Download pre-compiled [third-party libraries](https://aspia.org/files/third_party_small.7z).
    If you want to compile these libraries yourself, then you must follow the instructions for compiling these libraries.


### PR DESCRIPTION
When installing fresh instance of VS with SDK 8.1 it doesn't create file
C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt.
VC folder didn't exists.
CMake is looking for it to determine version on VS.
Installing with "Desktop development with C++" solves this problem, but require much more disk space.