### PR TITLE
* Fix compilation on Fedora

### DIFF
--- a/source/base/crypto/password_generator.h
+++ b/source/base/crypto/password_generator.h
@@ -21,6 +21,7 @@
 
 #include "base/macros_magic.h"
 
+#include <cstdint>
 #include <string>
 
 namespace base {

--- a/source/base/crypto/srp_constants.h
+++ b/source/base/crypto/srp_constants.h
@@ -19,6 +19,7 @@
 #ifndef BASE_CRYPTO_SRP_CONSTANTS_H
 #define BASE_CRYPTO_SRP_CONSTANTS_H
 
+#include <cstdint>
 #include <optional>
 #include <string_view>
 

--- a/source/base/guid.h
+++ b/source/base/guid.h
@@ -19,6 +19,7 @@
 #ifndef BASE_GUID_H
 #define BASE_GUID_H
 
+#include <cstdint>
 #include <string>
 
 namespace base {

--- a/source/base/net/address.h
+++ b/source/base/net/address.h
@@ -21,6 +21,7 @@
 
 #include "build/build_config.h"
 
+#include <cstdint>
 #include <string>
 
 namespace base {

--- a/source/base/service.h
+++ b/source/base/service.h
@@ -26,6 +26,9 @@
 #include "base/win/session_status.h"
 #endif // defined(OS_WIN)
 
+#include <string_view>
+#include <string>
+
 namespace base {
 
 namespace {

--- a/source/base/strings/string_util.cc
+++ b/source/base/strings/string_util.cc
@@ -21,6 +21,8 @@
 #include "base/strings/string_util_constants.h"
 #include "base/strings/unicode.h"
 
+#include <cstdint>
+
 namespace base {
 
 namespace {

--- a/source/base/sys_info.h
+++ b/source/base/sys_info.h
@@ -21,6 +21,7 @@
 
 #include "base/macros_magic.h"
 
+#include <cstdint>
 #include <string>
 
 namespace base {


### PR DESCRIPTION
By compiling on Fedora 38 I got several similar errors:

```
[  8%] Building CXX object source/base/CMakeFiles/aspia_base.dir/guid.cc.o
In file included from /home/albert/Downloads/3rd/aspia/source/base/guid.cc:19:
/home/albert/Downloads/3rd/aspia/source/base/guid.h:64:53: error: ‘uint64_t’ does not name a type
   64 |     static std::string randomDataToGUIDString(const uint64_t bytes[2]);
      |                                                     ^~~~~~~~
/home/albert/Downloads/3rd/aspia/source/base/guid.h:23:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
```

One should include explicitly all appropriate headers for every entity used.

## Proposed changes

Adding missing headers solves compilation errors.
