### PR TITLE
Add console theme support

### DIFF
--- a/source/console/CMakeLists.txt
+++ b/source/console/CMakeLists.txt
@@ -84,6 +84,8 @@ list(APPEND SOURCE_CONSOLE
     open_address_book_dialog.ui
     settings.cc
     settings.h
+    theme_manager.cc
+    theme_manager.h
     statusbar.cc
     statusbar.h
     update_settings_dialog.cc

--- a/source/console/main_window.cc
+++ b/source/console/main_window.cc
@@ -20,9 +20,11 @@
 
 #include <QActionGroup>
 #include <QCloseEvent>
+#include <QCoreApplication>
 #include <QDesktopServices>
 #include <QFileDialog>
 #include <QMessageBox>
+#include <QStyle>
 #include <QSystemTrayIcon>
 
 #include "base/logging.h"
@@ -41,10 +43,20 @@
 #include "console/fast_connect_dialog.h"
 #include "console/import_export_util.h"
 #include "console/mru_action.h"
-#include "console/update_settings_dialog.h"
 #include "console/settings.h"
+#include "console/theme_manager.h"
+#include "console/update_settings_dialog.h"
 
 namespace console {
+
+namespace {
+
+QString translateThemeName(const char* source_text)
+{
+    return QCoreApplication::translate("ConsoleMainWindow", source_text);
+}
+
+} // namespace
 
 //--------------------------------------------------------------------------------------------------
 MainWindow::MainWindow(const QString& file_path)
@@ -57,6 +69,10 @@ MainWindow::MainWindow(const QString& file_path)
 
     ui.setupUi(this);
     createLanguageMenu(settings.locale());
+
+    const QString current_theme = settings.theme();
+    createThemeMenu(current_theme);
+    applyTheme(current_theme);
 
     bool large_icons = settings.largeIcons();
     ui.tool_bar->setIconSize(large_icons ? QSize(32, 32) : QSize(24, 24));
@@ -158,6 +174,7 @@ MainWindow::MainWindow(const QString& file_path)
     connect(ui.tab_widget, &QTabWidget::currentChanged, this, &MainWindow::onCurrentTabChanged);
     connect(ui.tab_widget, &QTabWidget::tabCloseRequested, this, &MainWindow::onCloseTab);
     connect(ui.menu_language, &QMenu::triggered, this, &MainWindow::onLanguageChanged);
+    connect(ui.menu_theme, &QMenu::triggered, this, &MainWindow::onThemeChanged);
     connect(ui.action_large_icons, &QAction::toggled, this, [this](bool enable)
     {
         ui.tool_bar->setIconSize(enable ? QSize(32, 32) : QSize(24, 24));
@@ -1290,6 +1307,7 @@ void MainWindow::onLanguageChanged(QAction* action)
     application->setLocale(new_locale);
 
     ui.retranslateUi(this);
+    retranslateThemeMenu();
 
     for (int i = 0; i < ui.tab_widget->count(); ++i)
         static_cast<AddressBookTab*>(ui.tab_widget->widget(i))->retranslateUi();
@@ -1495,6 +1513,68 @@ void MainWindow::createLanguageMenu(const QString& current_locale)
 
         ui.menu_language->addAction(action_language);
     }
+}
+
+//--------------------------------------------------------------------------------------------------
+void MainWindow::createThemeMenu(const QString& current_theme)
+{
+    const QStringList available_themes = ThemeManager::instance()->availableThemes();
+    QActionGroup* theme_group = new QActionGroup(this);
+
+    theme_group->setExclusive(true);
+
+    for (const QString& theme_id : available_themes)
+    {
+        QAction* action = new QAction(themeName(theme_id), this);
+        action->setCheckable(true);
+        action->setData(theme_id);
+        action->setActionGroup(theme_group);
+        action->setChecked(theme_id == current_theme);
+        ui.menu_theme->addAction(action);
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+QString MainWindow::themeName(const QString& theme_id) const
+{
+    if (theme_id == QStringLiteral("dark"))
+        return translateThemeName("Dark");
+
+    return translateThemeName("Light");
+}
+
+//--------------------------------------------------------------------------------------------------
+void MainWindow::retranslateThemeMenu()
+{
+    for (QAction* action : ui.menu_theme->actions())
+    {
+        const QString theme_id = action->data().toString();
+        if (!theme_id.isEmpty())
+            action->setText(themeName(theme_id));
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+void MainWindow::applyTheme(const QString& theme_id)
+{
+    ThemeManager::instance()->applyTheme(Application::instance(), theme_id);
+
+    if (style())
+        ui.menu_theme->setIcon(style()->standardIcon(QStyle::SP_DesktopIcon));
+}
+
+//--------------------------------------------------------------------------------------------------
+void MainWindow::onThemeChanged(QAction* action)
+{
+    if (!action)
+        return;
+
+    const QString theme_id = action->data().toString();
+    if (theme_id.isEmpty())
+        return;
+
+    applyTheme(theme_id);
+    Settings().setTheme(theme_id);
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/source/console/main_window.h
+++ b/source/console/main_window.h
@@ -96,11 +96,15 @@ private slots:
     void onComputerDoubleClicked(const proto::address_book::Computer& computer);
     void onTabContextMenu(const QPoint& pos);
     void onLanguageChanged(QAction* action);
+    void onThemeChanged(QAction* action);
     void onRecentOpenTriggered(QAction* action);
     void onShowHideToTray();
 
 private:
     void createLanguageMenu(const QString& current_locale);
+    void createThemeMenu(const QString& current_theme);
+    QString themeName(const QString& theme_id) const;
+    void retranslateThemeMenu();
     void rebuildMruMenu();
     void showTrayIcon(bool show);
     void addAddressBookTab(AddressBookTab* tab);
@@ -111,6 +115,7 @@ private:
                            const QString& display_name,
                            const std::optional<client::RouterConfig>& router_config);
     void connectToRouter();
+    void applyTheme(const QString& theme_id);
 
     Ui::ConsoleMainWindow ui;
     Mru mru_;

--- a/source/console/main_window.ui
+++ b/source/console/main_window.ui
@@ -139,6 +139,13 @@
      </property>
     </widget>
     <addaction name="menu_language"/>
+    <widget class="QMenu" name="menu_theme">
+     <property name="title">
+      <string>&amp;Theme</string>
+     </property>
+    </widget>
+    <addaction name="menu_theme"/>
+    <addaction name="separator"/>
     <addaction name="action_toolbar"/>
     <addaction name="action_statusbar"/>
     <addaction name="action_large_icons"/>

--- a/source/console/settings.cc
+++ b/source/console/settings.cc
@@ -49,6 +49,7 @@ const QString kComputerGroupDialogGeometryParam = "ComputerGroupDialogGeometry";
 const QString kShowIconsInMenusParam = "ShowIconsInMenus";
 const QString kAddressBookDialogGeometryParam = "AddressBookDialogGeometry";
 const QString kLargeIconsParam = "LargeIcons";
+const QString kThemeParam = "Theme";
 
 } // namespace
 
@@ -330,6 +331,18 @@ bool Settings::largeIcons() const
 void Settings::setLargeIcons(bool enable)
 {
     settings_.setValue(kLargeIconsParam, enable);
+}
+
+//--------------------------------------------------------------------------------------------------
+QString Settings::theme() const
+{
+    return settings_.value(kThemeParam, QStringLiteral("light")).toString();
+}
+
+//--------------------------------------------------------------------------------------------------
+void Settings::setTheme(const QString& theme_id)
+{
+    settings_.setValue(kThemeParam, theme_id);
 }
 
 } // namespace console

--- a/source/console/settings.h
+++ b/source/console/settings.h
@@ -97,6 +97,9 @@ public:
     bool largeIcons() const;
     void setLargeIcons(bool enable);
 
+    QString theme() const;
+    void setTheme(const QString& theme_id);
+
 private:
     QSettings settings_;
     Q_DISABLE_COPY_MOVE(Settings)

--- a/source/console/theme_manager.cc
+++ b/source/console/theme_manager.cc
@@ -1,0 +1,152 @@
+//
+// Aspia Project
+// Copyright (C) 2016-2026 Dmitry Chapyshev <dmitry@aspia.ru>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+#include "console/theme_manager.h"
+
+#include <QStyleFactory>
+
+namespace console {
+
+//--------------------------------------------------------------------------------------------------
+ThemeManager* ThemeManager::instance()
+{
+    static ThemeManager theme_manager;
+    return &theme_manager;
+}
+
+//--------------------------------------------------------------------------------------------------
+QStringList ThemeManager::availableThemes() const
+{
+    return { QStringLiteral("light"), QStringLiteral("dark") };
+}
+
+//--------------------------------------------------------------------------------------------------
+ThemeManager::Theme ThemeManager::getTheme(const QString& theme_id) const
+{
+    if (theme_id == QStringLiteral("dark"))
+    {
+        return {
+            QStringLiteral("dark"),
+            QStringLiteral("Fusion"),
+            createDarkPalette()
+        };
+    }
+
+    return {
+        QStringLiteral("light"),
+        QString(),
+        createSystemPalette()
+    };
+}
+
+//--------------------------------------------------------------------------------------------------
+void ThemeManager::applyTheme(QApplication* app, const QString& theme_id)
+{
+    if (!app)
+        return;
+
+    const Theme theme = getTheme(theme_id);
+
+    if (!theme.style_name.isEmpty())
+    {
+        if (!icon_size_saved_ && app->style())
+        {
+            QStyleOption option;
+            saved_icon_size_ = app->style()->pixelMetric(QStyle::PM_SmallIconSize, &option, nullptr);
+
+            if (saved_icon_size_ <= 0)
+            {
+                if (qEnvironmentVariableIsSet("ASPIA_SMALL_ICON_SIZE"))
+                    saved_icon_size_ = qEnvironmentVariableIntValue("ASPIA_SMALL_ICON_SIZE");
+
+                if (saved_icon_size_ < 16)
+                    saved_icon_size_ = 16;
+                else if (saved_icon_size_ > 48)
+                    saved_icon_size_ = 48;
+
+                if (saved_icon_size_ <= 0)
+                    saved_icon_size_ = 20;
+            }
+
+            icon_size_saved_ = true;
+        }
+
+        if (QStyle* style = QStyleFactory::create(theme.style_name))
+            app->setStyle(style);
+
+        app->setPalette(theme.palette);
+        return;
+    }
+
+    if (QStyle* style = createLightStyle())
+        app->setStyle(style);
+
+    app->setPalette(createSystemPalette());
+}
+
+QPalette ThemeManager::createDarkPalette() const
+{
+    QPalette palette;
+
+    palette.setColor(QPalette::Window, QColor(53, 53, 53));
+    palette.setColor(QPalette::WindowText, Qt::white);
+    palette.setColor(QPalette::Base, QColor(35, 35, 35));
+    palette.setColor(QPalette::AlternateBase, QColor(53, 53, 53));
+    palette.setColor(QPalette::ToolTipBase, QColor(53, 53, 53));
+    palette.setColor(QPalette::ToolTipText, Qt::white);
+    palette.setColor(QPalette::Text, Qt::white);
+    palette.setColor(QPalette::ButtonText, Qt::white);
+    palette.setColor(QPalette::Button, QColor(53, 53, 53));
+    palette.setColor(QPalette::Link, QColor(42, 130, 218));
+    palette.setColor(QPalette::Highlight, QColor(42, 130, 218));
+    palette.setColor(QPalette::HighlightedText, Qt::black);
+    palette.setColor(QPalette::Disabled, QPalette::Text, QColor(127, 127, 127));
+    palette.setColor(QPalette::Disabled, QPalette::WindowText, QColor(127, 127, 127));
+    palette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(127, 127, 127));
+    palette.setColor(QPalette::Disabled, QPalette::Highlight, QColor(80, 80, 80));
+
+    return palette;
+}
+
+//--------------------------------------------------------------------------------------------------
+QPalette ThemeManager::createSystemPalette() const
+{
+    return QPalette();
+}
+
+//--------------------------------------------------------------------------------------------------
+QStyle* ThemeManager::createLightStyle() const
+{
+    QStyle* base_style = nullptr;
+
+#if defined(Q_OS_WIN)
+    base_style = QStyleFactory::create(QStringLiteral("Windows"));
+#elif defined(Q_OS_MAC)
+    base_style = QStyleFactory::create(QStringLiteral("macos"));
+#endif
+
+    if (!base_style)
+        base_style = QStyleFactory::create(QStringLiteral("Fusion"));
+
+    if (!base_style)
+        base_style = QStyleFactory::create(QString());
+
+    return new CustomStyleProxy(base_style, saved_icon_size_);
+}
+
+} // namespace console

--- a/source/console/theme_manager.h
+++ b/source/console/theme_manager.h
@@ -1,0 +1,84 @@
+//
+// Aspia Project
+// Copyright (C) 2016-2026 Dmitry Chapyshev <dmitry@aspia.ru>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+//
+
+#ifndef CONSOLE_THEME_MANAGER_H
+#define CONSOLE_THEME_MANAGER_H
+
+#include <QApplication>
+#include <QPalette>
+#include <QProxyStyle>
+#include <QString>
+#include <QStringList>
+#include <QStyle>
+#include <QStyleOption>
+
+namespace console {
+
+class ThemeManager
+{
+public:
+    struct Theme
+    {
+        QString id;
+        QString style_name;
+        QPalette palette;
+    };
+
+    static ThemeManager* instance();
+
+    QStringList availableThemes() const;
+    Theme getTheme(const QString& theme_id) const;
+    void applyTheme(QApplication* app, const QString& theme_id);
+
+private:
+    class CustomStyleProxy final : public QProxyStyle
+    {
+    public:
+        explicit CustomStyleProxy(QStyle* base_style, int small_icon_size)
+            : QProxyStyle(base_style),
+              small_icon_size_(small_icon_size)
+        {}
+
+        int pixelMetric(
+            PixelMetric metric, const QStyleOption* option, const QWidget* widget) const final
+        {
+            if (metric == QStyle::PM_SmallIconSize)
+                return small_icon_size_;
+
+            return QProxyStyle::pixelMetric(metric, option, widget);
+        }
+
+    private:
+        const int small_icon_size_;
+    };
+
+    ThemeManager() = default;
+
+    QPalette createDarkPalette() const;
+    QPalette createSystemPalette() const;
+    QStyle* createLightStyle() const;
+
+    int saved_icon_size_ = 20;
+    bool icon_size_saved_ = false;
+
+    Q_DISABLE_COPY_MOVE(ThemeManager)
+};
+
+} // namespace console
+
+#endif // CONSOLE_THEME_MANAGER_H

--- a/source/translations/translations_cs.ts
+++ b/source/translations/translations_cs.ts
@@ -1170,6 +1170,18 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>

--- a/source/translations/translations_da.ts
+++ b/source/translations/translations_da.ts
@@ -1170,6 +1170,18 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>

--- a/source/translations/translations_de.ts
+++ b/source/translations/translations_de.ts
@@ -1208,6 +1208,18 @@
         <translation>&amp;Sprache</translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation>&amp;Thema</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation>Hell</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation>Dunkel</translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>

--- a/source/translations/translations_el.ts
+++ b/source/translations/translations_el.ts
@@ -1170,6 +1170,18 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>

--- a/source/translations/translations_es.ts
+++ b/source/translations/translations_es.ts
@@ -1186,6 +1186,18 @@
         <translation>&amp;Idioma</translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation>&amp;Tema</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation>Claro</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation>Oscuro</translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation>Herramientas</translation>

--- a/source/translations/translations_fa.ts
+++ b/source/translations/translations_fa.ts
@@ -1170,6 +1170,18 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>

--- a/source/translations/translations_fi.ts
+++ b/source/translations/translations_fi.ts
@@ -1170,6 +1170,18 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>

--- a/source/translations/translations_fr.ts
+++ b/source/translations/translations_fr.ts
@@ -1204,6 +1204,18 @@
         <translation>&amp;Language</translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation>&amp;Thème</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation>Clair</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation>Sombre</translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation>Outils</translation>

--- a/source/translations/translations_he.ts
+++ b/source/translations/translations_he.ts
@@ -1170,6 +1170,18 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>

--- a/source/translations/translations_hu.ts
+++ b/source/translations/translations_hu.ts
@@ -1170,6 +1170,18 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>

--- a/source/translations/translations_it.ts
+++ b/source/translations/translations_it.ts
@@ -1204,6 +1204,18 @@
         <translation>&amp;Lingua</translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation>&amp;Tema</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation>Chiaro</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation>Scuro</translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation>Strumenti</translation>

--- a/source/translations/translations_nl.ts
+++ b/source/translations/translations_nl.ts
@@ -1244,6 +1244,18 @@
         <translation>&amp;Taal</translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation>&amp;Thema</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation>Licht</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation>Donker</translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation>Gereedschappen</translation>

--- a/source/translations/translations_no.ts
+++ b/source/translations/translations_no.ts
@@ -1170,6 +1170,18 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>

--- a/source/translations/translations_pl.ts
+++ b/source/translations/translations_pl.ts
@@ -1170,6 +1170,18 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>

--- a/source/translations/translations_pt.ts
+++ b/source/translations/translations_pt.ts
@@ -1170,6 +1170,18 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>

--- a/source/translations/translations_pt_BR.ts
+++ b/source/translations/translations_pt_BR.ts
@@ -1252,6 +1252,18 @@
         <translation>&amp;Idioma</translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation>&amp;Tema</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation>Claro</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation>Escuro</translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation>Ferramentas</translation>

--- a/source/translations/translations_ru.ts
+++ b/source/translations/translations_ru.ts
@@ -1300,6 +1300,18 @@
         <translation>&amp;Язык</translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation>&amp;Тема</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation>Светлая</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation>Темная</translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation>Инструменты</translation>

--- a/source/translations/translations_sv.ts
+++ b/source/translations/translations_sv.ts
@@ -1170,6 +1170,18 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>

--- a/source/translations/translations_tr.ts
+++ b/source/translations/translations_tr.ts
@@ -1170,6 +1170,18 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation type="unfinished"></translation>

--- a/source/translations/translations_uk.ts
+++ b/source/translations/translations_uk.ts
@@ -1264,6 +1264,18 @@
         <translation>&amp;Мова</translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation>&amp;Тема</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation>Світла</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation>Темна</translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation>Інструменти</translation>

--- a/source/translations/translations_zh_CN.ts
+++ b/source/translations/translations_zh_CN.ts
@@ -1244,6 +1244,18 @@
         <translation>语言(&amp;L)</translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation>主题(&amp;T)</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation>浅色</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation>深色</translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation>工具</translation>

--- a/source/translations/translations_zh_TW.ts
+++ b/source/translations/translations_zh_TW.ts
@@ -1210,6 +1210,18 @@
         <translation>語言(&amp;L)</translation>
     </message>
     <message>
+        <source>&amp;Theme</source>
+        <translation>主題(&amp;T)</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation>淺色</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation>深色</translation>
+    </message>
+    <message>
         <location filename="../console/main_window.ui" line="155"/>
         <source>Tools</source>
         <translation>工具</translation>


### PR DESCRIPTION
  ## Purpose

  Add theme selection support to Aspia Console and resolve issue [#280](https://github.com/dchapyshev/aspia/issues/280).

  The change adds a light/dark theme switch to the Console UI, persists the selected theme in settings, applies the theme at startup, and updates the new menu entries in translations.

  ## Proposed changes

  - add a `Theme` submenu to the Console `View` menu with `Light` and `Dark` options
  - add `ThemeManager` for available themes and palette/style application
  - store the selected theme in console settings and restore it on startup
  - retranslate theme menu entries when the application language changes
  - add translations for the new menu items in existing translation files