### PR TITLE
Handle Console file open events on macOS

### DIFF
--- a/source/console/Info.plist
+++ b/source/console/Info.plist
@@ -9,9 +9,9 @@
 	<key>CFBundleGetInfoString</key>
 	<string>Aspia Console</string>
 	<key>CFBundleIconFile</key>
-	<string></string>
+	<string>aspia-console.icns</string>
 	<key>CFBundleIdentifier</key>
-	<string></string>
+	<string>org.aspia.console</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleLongVersionString</key>
@@ -26,8 +26,47 @@
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>3.0.0</string>
-    <key>NSAppleEventsUsageDescription</key>
-    <string></string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>aspia-console.icns</string>
+			<key>CFBundleTypeName</key>
+			<string>Aspia Address Book</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.aspia.address-book</string>
+			</array>
+		</dict>
+	</array>
+	<key>UTExportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Aspia Address Book</string>
+			<key>UTTypeIconFile</key>
+			<string>aspia-console.icns</string>
+			<key>UTTypeIdentifier</key>
+			<string>org.aspia.address-book</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>aab</string>
+				</array>
+				<key>public.mime-type</key>
+				<string>application/aab</string>
+			</dict>
+		</dict>
+	</array>
 	<key>CSResourcesFileMapped</key>
 	<true/>
 	<key>NSHumanReadableCopyright</key>

--- a/source/console/application.cc
+++ b/source/console/application.cc
@@ -20,6 +20,11 @@
 
 #include <QIcon>
 
+#if defined(OS_MAC)
+#include <QFileOpenEvent>
+#include <QUrl>
+#endif
+
 #include "base/logging.h"
 #include "build/build_config.h"
 #include "build/version.h"
@@ -81,6 +86,34 @@ Application::Application(int& argc, char* argv[])
 Application::~Application()
 {
     LOG(INFO) << "Dtor";
+}
+
+//--------------------------------------------------------------------------------------------------
+bool Application::event(QEvent* event)
+{
+#if defined(OS_MAC)
+    if (event->type() == QEvent::FileOpen)
+    {
+        QFileOpenEvent* open_event = static_cast<QFileOpenEvent*>(event);
+        QString file_path;
+
+        const QUrl url = open_event->url();
+        if (url.isLocalFile())
+            file_path = url.toLocalFile();
+        else
+            file_path = open_event->file();
+
+        if (!file_path.isEmpty())
+        {
+            LOG(INFO) << "Open file from macOS event: " << file_path;
+            emit sig_fileOpened(file_path);
+            open_event->accept();
+            return true;
+        }
+    }
+#endif
+
+    return base::GuiApplication::event(event);
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/source/console/application.h
+++ b/source/console/application.h
@@ -21,6 +21,8 @@
 
 #include "base/gui_application.h"
 
+class QEvent;
+
 namespace console {
 
 class Application final : public base::GuiApplication
@@ -36,6 +38,9 @@ public:
 public slots:
     void activateWindow();
     void openFile(const QString& file_path);
+
+protected:
+    bool event(QEvent* event) final;
 
 signals:
     void sig_windowActivated();


### PR DESCRIPTION
This registers Aspia address books in the Console app bundle and handles QFileOpenEvent on macOS.

It lets .aab files opened from Finder use the existing address book open path.