### PR TITLE
Do not activate running instance on hidden launch.

### DIFF
--- a/source/host/ui/host_main.cc
+++ b/source/host/ui/host_main.cc
@@ -256,7 +256,11 @@ int hostMain(int argc, char* argv[])
         if (application.isRunning())
         {
             LOG(INFO) << "Application already running";
-            application.activate();
+
+            if (parser.isSet(hidden_option))
+                LOG(INFO) << "Hidden launch, keep the existing instance in the tray";
+            else
+                application.activate();
         }
         else
         {


### PR DESCRIPTION
## Purpose

Исправление бага: при автозапуске службой окно Host открывалось поверх
рабочего стола вместо сворачивания в трей.

Корень проблемы — запуск с ключом `--hidden` (его использует служба для
автозапуска UI) при наличии уже работающего экземпляра безусловно вызывал
`application.activate()`. Если при медленной загрузке системы служба успевала
переподключиться (таймаут ожидания UI 15 с истекал, пока UI ждал готовности
input-десктопа до 60 с) и запускала вторую `--hidden`-копию, эта копия
«активировала» первую, и скрытое окно выводилось на передний план.

Issue: [#338](https://github.com/dchapyshev/aspia/issues/338)

## Proposed changes

_Describe what you propose to change/add/fix with this pull request._

- Не вызывать `application.activate()` для запуска с ключом `--hidden`:
  фоновый/автозапуск больше не выводит уже работающий экземпляр на передний
  план, вторая скрытая копия завершается тихо. Ручной запуск без `--hidden`
  (ярлык, значок в трее) по-прежнему разворачивает окно как раньше.
- Добавлено информативное логирование (`Hidden launch, keep the existing
  instance in the tray`) для диагностики этого сценария.

## TODO

_Use a TODO when your pull request is Work in Progress._

- [ ] Собрать `local-win-x64` и убедиться, что изменение компилируется
- [ ] Проверить на медленно загружающейся машине: после перезагрузки Host
      стартует в трее, окно не появляется
- [ ] Проверить, что ручной запуск/повторный запуск по-прежнему разворачивает окно
